### PR TITLE
Do not trigger stop when current position equals last position

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,9 +73,7 @@ BlindsHTTPAccessory.prototype.setTargetPosition = function(pos, callback) {
     if (this.currentTargetPosition == this.lastPosition) {
         if (this.interval != null) clearInterval(this.interval);
         if (this.timeout != null) clearTimeout(this.timeout);
-        this.httpRequest(this.stopURL, this.httpMethod, function() {
-            this.log("Already here");
-        }.bind(this));
+        this.log("Already here");
         callback(null);
         return;
     }


### PR DESCRIPTION
I noticed strange behaviour with my blinds because STOP is being fired when the requested position is similar to the previous position.

No need to fire a stop http request in that situation I guess.