### PR TITLE
Refactor opening/closing logic; persist state

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Add the accessory in `config.json` in your home directory inside `.homebridge`.
         "method": "PUT"
       },
       "trigger_stop_at_boundaries": false,
-      "success_codes": [ 200, 204 ]
+      "success_codes": [ 200, 204 ],
+      "verbose": false
     }
 ```
 
@@ -47,6 +48,8 @@ You can omit `http_method`, it defaults to `POST`. Note that it can be configure
 `success_codes` allows you to define which HTTP response codes indicate a successful server response. If omitted, it defaults to 200.
 
 `trigger_stop_at_boundaries` allows you to choose if a stop command should be fired or not when moving the blinds to position 0 or 100.  Most blinds dont require this command and will stop by themself, for such blinds it is advised to set this to `false`.
+
+`verbose` is optional and shows getTargetPosition / getTargetState / getCurrentPosition requests
 
 ## Note
 Currently the plugin only emulates the position (it saves it in a variable), because my blinds only support

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Add the accessory in `config.json` in your home directory inside `.homebridge`.
       "up_url": "http://1.2.3.4/window/up",
       "down_url": "http://1.2.3.4/window/down",
       "stop_url": "http://1.2.3.4/window/stop",
-      "motion_time": "<time your blind needs to move from up to down (in milliseconds)>",
+      "motion_time": 10000,
+      "response_lag": 0,
       "http_method": {
         "body": "{}",
         "headers": {
@@ -44,6 +45,10 @@ Add the accessory in `config.json` in your home directory inside `.homebridge`.
 ```
 
 You can omit `http_method`, it defaults to `POST`. Note that it can be configured to accept any number of additional arguments (headers, body, form, etc.) that [request](https://github.com/request/request) supports.
+
+`motion_time` is the time, in milliseconds, for your blinds to move from up to down.
+
+`response_lag` is an optional parameter used to improve the calculation for setting a specific blinds position. `expected_wait_time` = (`current_position` - `target_position`) / 100 * `motion_time` - `response_lag`.
 
 `success_codes` allows you to define which HTTP response codes indicate a successful server response. If omitted, it defaults to 200.
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,17 @@ Add the accessory in `config.json` in your home directory inside `.homebridge`.
     }
 ```
 
+You can omit any of the `up_url`, `down_url`, etc. if you don't want these to send a command.
+
 You can omit `http_method`, it defaults to `POST`. Note that it can be configured to accept any number of additional arguments (headers, body, form, etc.) that [request](https://github.com/request/request) supports.
 
-`motion_time` is the time, in milliseconds, for your blinds to move from up to down.
+`motion_time` is the time, in milliseconds, for your blinds to move from up to down. This should only include the time the motor is running.
 
-`response_lag` is an optional parameter used to improve the calculation for setting a specific blinds position. `expected_wait_time` = (`current_position` - `target_position`) / 100 * `motion_time` - `response_lag`.
+`response_lag` is an optional parameter used to improve the calculation for setting a specific blinds position. It takes into account the delay of the device you are using control the blinds (RF transmitter or otherwise). This is useful since it will do a better job of not under/overshooting the target:
+
+1. Send HTTP command to url
+2. Wait `response_lag`; expected finish time (`current_position` - `target_position`) / 100 * `motion_time`
+4. Send stop command at (`current_position` - `target_position`) / 100 * `motion_time` - `response_lag`
 
 `success_codes` allows you to define which HTTP response codes indicate a successful server response. If omitted, it defaults to 200.
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ function BlindsHTTPAccessory(log, config) {
     this.stopAtBoundaries = config.trigger_stop_at_boundaries;
     this.httpMethod = config.http_method || { method: "POST" };
     this.successCodes = config.success_codes || [200];
-    this.motionTime = parseInt(config.motion_time, 10);
+    this.motionTime = parseInt(config.motion_time, 10) || 10000;
+    this.responseLag = parseInt(config.response_lag, 10) || 0;
     this.verbose = config.verbose || false;
 
     this.cacheDirectory = HomebridgeAPI.user.persistPath();
@@ -112,6 +113,15 @@ BlindsHTTPAccessory.prototype.setTargetPosition = function(pos, callback) {
     }.bind(this));
 
     let self = this;
+
+    if (this.responseLag > 0) {
+        setTimeout(function() {
+            if (self.verbose) {
+                self.log(`Waiting ${Math.round(self.responseLag / 100) / 10} seconds for response lag`);
+            }
+        }, this.responseLag);
+    }
+
     this.interval = setInterval(function() {
         if (self.lastPosition == self.currentTargetPosition) {
             self.currentPositionState = Characteristic.PositionState.STOPPED;

--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ function BlindsHTTPAccessory(log, config) {
 
     // configuration vars
     this.name = config.name;
-    this.upURL = config.up_url;
-    this.downURL = config.down_url;
-    this.stopURL = config.stop_url;
+    this.upURL = config.up_url || false;
+    this.downURL = config.down_url || false;
+    this.stopURL = config.stop_url || false;
     this.stopAtBoundaries = config.trigger_stop_at_boundaries || false;
     this.httpMethod = config.http_method || { method: "POST" };
     this.successCodes = config.success_codes || [200];
@@ -134,7 +134,7 @@ BlindsHTTPAccessory.prototype.setTargetPosition = function(pos, callback) {
             if (self.stopAtBoundaries || self.currentTargetPosition % 100 > 0) {
                 self.httpRequest(self.stopURL, self.httpMethod, function(err) {
                     if (err) {
-                        self.log("Stop request failed");
+                        self.log.warn("Stop request failed");
                     } else {
                         self.log("Stop request sent");
                     }
@@ -150,12 +150,14 @@ BlindsHTTPAccessory.prototype.setTargetPosition = function(pos, callback) {
 }
 
 BlindsHTTPAccessory.prototype.httpRequest = function(url, methods, callback) {
+    if (!url) callback(null);
+
     var options = Object.assign({ url: url }, methods);
     request(options, function(err, response, body) {
         if (!err && response && this.successCodes.includes(response.statusCode)) {
             callback(null);
         } else {
-            this.log(`Error sending request (HTTP status code ${response ? response.statusCode : 'not defined'}): ${err}`);
+            this.log.error(`Error sending request (HTTP status code ${response ? response.statusCode : 'not defined'}): ${err}`);
             callback(err);
         }
     }.bind(this));

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ function BlindsHTTPAccessory(log, config) {
         .on('get', this.getTargetPosition.bind(this))
         .on('set', this.setTargetPosition.bind(this));
 
-    this.service.getCharacteristic(Characteristic.PositionState)
+    this.service
+        .getCharacteristic(Characteristic.PositionState)
         .updateValue(Characteristic.PositionState.STOPPED);
 }
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,9 @@ function BlindsHTTPAccessory(log, config) {
         .getCharacteristic(Characteristic.TargetPosition)
         .on('get', this.getTargetPosition.bind(this))
         .on('set', this.setTargetPosition.bind(this));
+
+    this.service.getCharacteristic(Characteristic.PositionState)
+        .updateValue(Characteristic.PositionState.STOPPED);
 }
 
 BlindsHTTPAccessory.prototype.getCurrentPosition = function(callback) {

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ BlindsHTTPAccessory.prototype.setTargetPosition = function(pos, callback) {
         }
     }
 
-    const moveUp = (this.currentTargetPosition >= this.lastPosition);
+    const moveUp = (this.currentTargetPosition > this.lastPosition || this.currentTargetPosition == 1);
     const moveMessage = `Move ${moveUp ? 'up' : 'down'}`;
     this.log(`Requested ${moveMessage} (to ${this.currentTargetPosition}%)`);
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function BlindsHTTPAccessory(log, config) {
     this.upURL = config.up_url;
     this.downURL = config.down_url;
     this.stopURL = config.stop_url;
-    this.stopAtBoundaries = config.trigger_stop_at_boundaries;
+    this.stopAtBoundaries = config.trigger_stop_at_boundaries || false;
     this.httpMethod = config.http_method || { method: "POST" };
     this.successCodes = config.success_codes || [200];
     this.motionTime = parseInt(config.motion_time, 10) || 10000;

--- a/index.js
+++ b/index.js
@@ -115,9 +115,12 @@ BlindsHTTPAccessory.prototype.setTargetPosition = function(pos, callback) {
     let self = this;
 
     if (this.responseLag > 0) {
+        if (this.verbose) {
+            this.log(`Waiting ${Math.round(this.responseLag / 100) / 10} seconds for response lag`);
+        }
         setTimeout(function() {
             if (self.verbose) {
-                self.log(`Waiting ${Math.round(self.responseLag / 100) / 10} seconds for response lag`);
+                self.log("Response lag ended");
             }
         }, this.responseLag);
     }

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ BlindsHTTPAccessory.prototype.setTargetPosition = function(pos, callback) {
         const motionTimeSinglePct = this.motionTime / 100;
 
         let needsSendStopRequest = this.stopAtBoundaries || this.currentTargetPosition % 100 > 0;
-        const sendStopAtPositionDiff = Math.round(this.responseLag / motionTimeSinglePct);
+        const sendStopAtPositionDiff = (motionTimeSinglePct > 0) ? Math.round(this.responseLag / motionTimeSinglePct) : 0;
 
         const waitDelay = Math.abs(this.currentTargetPosition - this.lastPosition) * motionTimeSinglePct;
         this.log(`Move request sent, waiting ${Math.round(waitDelay / 100) / 10}s (+ response lag of ${Math.round(this.responseLag / 100) / 10}s)...`);

--- a/index.js
+++ b/index.js
@@ -121,6 +121,8 @@ BlindsHTTPAccessory.prototype.setTargetPosition = function(pos, callback) {
                     self.log(`End ${moveMessage} (to ${self.currentTargetPosition}%)`);
                     self.service.getCharacteristic(Characteristic.CurrentPosition)
                         .updateValue(self.lastPosition);
+                    self.service.getCharacteristic(Characteristic.PositionState)
+                        .updateValue(Characteristic.PositionState.STOPPED);
                     clearInterval(self.interval);
                 } else {
                     self.lastPosition += (moveUp ? 1 : -1);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Robin Temme <zwerch1337@googlemail.com>",
   "license": "ISC",
   "dependencies": {
+    "node-persist": "^2.1.0",
     "request": "^2.88.0"
   }
 }


### PR DESCRIPTION
Made a number of changes and improvements:

- Persist cached blinds position across Homebridge restarts
- Simplified/refactored logic for calculating current blind position and whether or not to send `Stop` command
- Also send 'Opening' or 'Closing' state
- Added `response_lag` parameter to improve % calculation
- Tweaked config settings, made certain settings optional and added default values
- Minor improvements to code formatting/structure